### PR TITLE
Add cluster debug message extension

### DIFF
--- a/src/cluster.h
+++ b/src/cluster.h
@@ -60,6 +60,7 @@ void clusterUpdateMyselfClientIpV6(void);
 void clusterUpdateMyselfHostname(void);
 void clusterUpdateMyselfAnnouncedPorts(void);
 void clusterUpdateMyselfHumanNodename(void);
+void clusterUpdateMyselfDebugMessage(void);
 
 void clusterPropagatePublish(robj *channel, robj *message, int sharded);
 

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1088,6 +1088,10 @@ static void updateAnnouncedClientIpV6(clusterNode *node, char *value) {
     updateSdsExtensionField(&node->announce_client_ipv6, value);
 }
 
+static void updateDebugMessage(clusterNode *node, char *value) {
+    updateSdsExtensionField(&node->debug_message, value);
+}
+
 static void updateShardId(clusterNode *node, const char *shard_id) {
     if (shard_id && memcmp(node->shard_id, shard_id, CLUSTER_NAMELEN) != 0) {
         clusterRemoveNodeFromShard(node);
@@ -1134,6 +1138,11 @@ void clusterUpdateMyselfClientIpV4(void) {
 void clusterUpdateMyselfClientIpV6(void) {
     if (!myself) return;
     updateAnnouncedClientIpV6(myself, server.cluster_announce_client_ipv6);
+}
+
+void clusterUpdateMyselfDebugMessage(void) {
+    if (!myself) return;
+    updateDebugMessage(myself, server.cluster_bus_debug_msg);
 }
 
 void clusterInit(void) {
@@ -1226,6 +1235,7 @@ void clusterInit(void) {
     clusterUpdateMyselfClientIpV6();
     clusterUpdateMyselfHostname();
     clusterUpdateMyselfHumanNodename();
+    clusterUpdateMyselfDebugMessage();
     resetClusterStats();
 }
 
@@ -1566,6 +1576,7 @@ clusterNode *createClusterNode(char *nodename, int flags) {
     node->announce_client_ipv6 = sdsempty();
     node->hostname = sdsempty();
     node->human_nodename = sdsempty();
+    node->debug_message = sdsempty();
     node->tcp_port = 0;
     node->cport = 0;
     node->tls_port = 0;
@@ -1751,6 +1762,7 @@ void freeClusterNode(clusterNode *n) {
     /* Free these members after links are freed, as freeClusterLink may access them. */
     sdsfree(n->hostname);
     sdsfree(n->human_nodename);
+    sdsfree(n->debug_message);
     sdsfree(n->announce_client_ipv4);
     sdsfree(n->announce_client_ipv6);
     listRelease(n->fail_reports);
@@ -2877,6 +2889,8 @@ static uint32_t writePingExtensions(clusterMsg *hdr, int gossipcount) {
         writeSdsPingExtIfNonempty(&totlen, &cursor, CLUSTERMSG_EXT_TYPE_CLIENT_IPV4, myself->announce_client_ipv4);
     extensions +=
         writeSdsPingExtIfNonempty(&totlen, &cursor, CLUSTERMSG_EXT_TYPE_CLIENT_IPV6, myself->announce_client_ipv6);
+    extensions +=
+        writeSdsPingExtIfNonempty(&totlen, &cursor, CLUSTERMSG_EXT_TYPE_DEBUG_MESSAGE, server.cluster_bus_debug_msg);
 
     /* Gossip forgotten nodes */
     if (dictSize(server.cluster->nodes_black_list) > 0) {
@@ -2929,6 +2943,7 @@ void clusterProcessPingExtensions(clusterMsg *hdr, clusterLink *link) {
     char *ext_clientipv4 = NULL;
     char *ext_clientipv6 = NULL;
     char *ext_shardid = NULL;
+    char *ext_debug_message = NULL;
     uint16_t extensions = ntohs(hdr->extensions);
     /* Loop through all the extensions and process them */
     clusterMsgPingExt *ext = getInitialPingExt(hdr, ntohs(hdr->count));
@@ -2949,6 +2964,10 @@ void clusterProcessPingExtensions(clusterMsg *hdr, clusterLink *link) {
             clusterMsgPingExtClientIpV6 *clientipv6_ext =
                 (clusterMsgPingExtClientIpV6 *)&(ext->ext[0].announce_client_ipv6);
             ext_clientipv6 = clientipv6_ext->announce_client_ipv6;
+        } else if (type == CLUSTERMSG_EXT_TYPE_DEBUG_MESSAGE) {
+            clusterMsgPingExtDebugMessage *debug_ext =
+                (clusterMsgPingExtDebugMessage *)&(ext->ext[0].debug_message);
+            ext_debug_message = debug_ext->debug_msg;
         } else if (type == CLUSTERMSG_EXT_TYPE_FORGOTTEN_NODE) {
             clusterMsgPingExtForgottenNode *forgotten_node_ext = &(ext->ext[0].forgotten_node);
             clusterNode *n = clusterLookupNode(forgotten_node_ext->name, CLUSTER_NAMELEN);
@@ -2983,6 +3002,13 @@ void clusterProcessPingExtensions(clusterMsg *hdr, clusterLink *link) {
     updateAnnouncedHumanNodename(sender, ext_humannodename);
     updateAnnouncedClientIpV4(sender, ext_clientipv4);
     updateAnnouncedClientIpV6(sender, ext_clientipv6);
+    if (ext_debug_message &&
+        sdscmp(sender->debug_message, ext_debug_message) != 0) {
+        sdsfree(server.cluster_bus_debug_msg);
+        server.cluster_bus_debug_msg = sdsnew(ext_debug_message);
+        clusterUpdateMyselfDebugMessage();
+    }
+    updateDebugMessage(sender, ext_debug_message);
     /* If the node did not send us a shard-id extension, it means the sender
      * does not support it (old version), node->shard_id is randomly generated.
      * A cluster-wide consensus for the node's shard_id is not necessary.

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3002,12 +3002,6 @@ void clusterProcessPingExtensions(clusterMsg *hdr, clusterLink *link) {
     updateAnnouncedHumanNodename(sender, ext_humannodename);
     updateAnnouncedClientIpV4(sender, ext_clientipv4);
     updateAnnouncedClientIpV6(sender, ext_clientipv6);
-    if (ext_debug_message &&
-        sdscmp(sender->debug_message, ext_debug_message) != 0) {
-        sdsfree(server.cluster_bus_debug_msg);
-        server.cluster_bus_debug_msg = sdsnew(ext_debug_message);
-        clusterUpdateMyselfDebugMessage();
-    }
     updateDebugMessage(sender, ext_debug_message);
     /* If the node did not send us a shard-id extension, it means the sender
      * does not support it (old version), node->shard_id is randomly generated.

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1142,7 +1142,7 @@ void clusterUpdateMyselfClientIpV6(void) {
 
 void clusterUpdateMyselfDebugMessage(void) {
     if (!myself) return;
-    updateDebugMessage(myself, server.cluster_bus_debug_msg);
+    updateDebugMessage(myself, server.cluster->myself->debug_message);
 }
 
 void clusterInit(void) {
@@ -2890,7 +2890,7 @@ static uint32_t writePingExtensions(clusterMsg *hdr, int gossipcount) {
     extensions +=
         writeSdsPingExtIfNonempty(&totlen, &cursor, CLUSTERMSG_EXT_TYPE_CLIENT_IPV6, myself->announce_client_ipv6);
     extensions +=
-        writeSdsPingExtIfNonempty(&totlen, &cursor, CLUSTERMSG_EXT_TYPE_DEBUG_MESSAGE, server.cluster_bus_debug_msg);
+        writeSdsPingExtIfNonempty(&totlen, &cursor, CLUSTERMSG_EXT_TYPE_DEBUG_MESSAGE, myself->debug_message);
 
     /* Gossip forgotten nodes */
     if (dictSize(server.cluster->nodes_black_list) > 0) {

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -160,10 +160,14 @@ typedef enum {
     CLUSTERMSG_EXT_TYPE_SHARDID,
     CLUSTERMSG_EXT_TYPE_CLIENT_IPV4,
     CLUSTERMSG_EXT_TYPE_CLIENT_IPV6,
+    CLUSTERMSG_EXT_TYPE_DEBUG_MESSAGE,
 } clusterMsgPingtypes;
 
 /* Helper function for making sure extensions are eight byte aligned. */
 #define EIGHT_BYTE_ALIGN(size) ((((size) + 7) / 8) * 8)
+
+/* Maximum length for debug-message extension. */
+#define CLUSTERMSG_MAX_DEBUG_MESSAGE 1024
 
 typedef struct {
     char hostname[1]; /* The announced hostname, ends with \0. */
@@ -193,6 +197,10 @@ typedef struct {
 } clusterMsgPingExtClientIpV6;
 
 typedef struct {
+    char debug_msg[1]; /* Debug message, ends with \0. */
+} clusterMsgPingExtDebugMessage;
+
+typedef struct {
     uint32_t length; /* Total length of this extension message (including this header) */
     uint16_t type;   /* Type of this extension message (see clusterMsgPingtypes) */
     uint16_t unused; /* 16 bits of padding to make this structure 8 byte aligned. */
@@ -203,6 +211,7 @@ typedef struct {
         clusterMsgPingExtShardId shard_id;
         clusterMsgPingExtClientIpV4 announce_client_ipv4;
         clusterMsgPingExtClientIpV6 announce_client_ipv6;
+        clusterMsgPingExtDebugMessage debug_message;
     } ext[]; /* Actual extension information, formatted so that the data is 8
               * byte aligned, regardless of its content. */
 } clusterMsgPingExt;
@@ -360,6 +369,7 @@ struct _clusterNode {
     sds announce_client_ipv6;               /* IPv6 for clients only. */
     sds hostname;                           /* The known hostname for this node */
     sds human_nodename;                     /* The known human readable nodename for this node */
+    sds debug_message;                      /* Debug message from this node */
     int tcp_port;                           /* Latest known clients TCP port. */
     int tls_port;                           /* Latest known clients TLS port */
     int cport;                              /* Latest known cluster port of this node. */

--- a/src/debug.c
+++ b/src/debug.c
@@ -443,7 +443,7 @@ void debugCommand(client *c) {
             "    Disable sending cluster ping to a random node every second.",
             "CLUSTER-MSG-SET <message>",
             "    Set debug message to include in cluster ping/pong packets (max 1KB).",
-            "CLUSTERMSGGET <node-id>",
+            "CLUSTER-MSG-GET <node-id>",
             "    Get the debug message last received from the specified node.",
             "OOM",
             "    Crash the server simulating an out-of-memory error.",
@@ -629,7 +629,7 @@ void debugCommand(client *c) {
         server.cluster_bus_debug_msg = sdsdup(c->argv[2]->ptr);
         clusterUpdateMyselfDebugMessage();
         addReply(c, shared.ok);
-    } else if (!strcasecmp(c->argv[1]->ptr, "clustermsgget") && c->argc == 3) {
+    } else if (!strcasecmp(c->argv[1]->ptr, "cluster-msg-get") && c->argc == 3) {
         if (sdslen(c->argv[2]->ptr) != CLUSTER_NAMELEN) {
             addReplyError(c, "Invalid node-id length");
             return;

--- a/src/debug.c
+++ b/src/debug.c
@@ -625,8 +625,8 @@ void debugCommand(client *c) {
             addReplyError(c, "Message too long (max 1KB)");
             return;
         }
-        sdsfree(server.cluster_bus_debug_msg);
-        server.cluster_bus_debug_msg = sdsdup(c->argv[2]->ptr);
+        sdsfree(server.cluster->myself->debug_message);
+        server.cluster->myself->debug_message = sdsdup(c->argv[2]->ptr);
         clusterUpdateMyselfDebugMessage();
         addReply(c, shared.ok);
     } else if (!strcasecmp(c->argv[1]->ptr, "cluster-msg-get") && c->argc == 3) {

--- a/src/debug.c
+++ b/src/debug.c
@@ -35,6 +35,7 @@
 #include "quicklist.h"
 #include "fpconv_dtoa.h"
 #include "cluster.h"
+#include "cluster_legacy.h"
 #include "threads_mngr.h"
 #include "io_threads.h"
 #include "sds.h"
@@ -440,6 +441,10 @@ void debugCommand(client *c) {
             "    When set to 1, the cluster link is closed after dropping a packet based on the filter.",
             "DISABLE-CLUSTER-RANDOM-PING <0|1>",
             "    Disable sending cluster ping to a random node every second.",
+            "CLUSTER-MSG-SET <message>",
+            "    Set debug message to include in cluster ping/pong packets (max 1KB).",
+            "CLUSTERMSGGET <node-id>",
+            "    Get the debug message last received from the specified node.",
             "OOM",
             "    Crash the server simulating an out-of-memory error.",
             "PANIC",
@@ -614,6 +619,27 @@ void debugCommand(client *c) {
     } else if (!strcasecmp(c->argv[1]->ptr, "disable-cluster-random-ping") && c->argc == 3) {
         server.debug_cluster_disable_random_ping = atoi(c->argv[2]->ptr);
         addReply(c, shared.ok);
+    } else if (!strcasecmp(c->argv[1]->ptr, "cluster-msg-set") && c->argc == 3) {
+        size_t len = sdslen(c->argv[2]->ptr);
+        if (len > CLUSTERMSG_MAX_DEBUG_MESSAGE) {
+            addReplyError(c, "Message too long (max 1KB)");
+            return;
+        }
+        sdsfree(server.cluster_bus_debug_msg);
+        server.cluster_bus_debug_msg = sdsdup(c->argv[2]->ptr);
+        clusterUpdateMyselfDebugMessage();
+        addReply(c, shared.ok);
+    } else if (!strcasecmp(c->argv[1]->ptr, "clustermsgget") && c->argc == 3) {
+        if (sdslen(c->argv[2]->ptr) != CLUSTER_NAMELEN) {
+            addReplyError(c, "Invalid node-id length");
+            return;
+        }
+        clusterNode *n = clusterLookupNode(c->argv[2]->ptr, CLUSTER_NAMELEN);
+        if (!n) {
+            addReplyError(c, "Unknown node-id");
+            return;
+        }
+        addReplyBulkCBuffer(c, n->debug_message, sdslen(n->debug_message));
     } else if (!strcasecmp(c->argv[1]->ptr, "object") && (c->argc == 3 || c->argc == 4)) {
         robj *val;
         char *strenc;

--- a/src/server.c
+++ b/src/server.c
@@ -2803,6 +2803,7 @@ void initServer(void) {
     server.thp_enabled = 0;
     server.cluster_drop_packet_filter = -1;
     server.debug_cluster_disable_random_ping = 0;
+    server.cluster_bus_debug_msg = sdsempty();
     server.reply_buffer_peak_reset_time = REPLY_BUFFER_DEFAULT_PEAK_RESET_TIME;
     server.reply_buffer_resizing_enabled = 1;
     server.client_mem_usage_buckets = NULL;

--- a/src/server.c
+++ b/src/server.c
@@ -2803,7 +2803,7 @@ void initServer(void) {
     server.thp_enabled = 0;
     server.cluster_drop_packet_filter = -1;
     server.debug_cluster_disable_random_ping = 0;
-    server.cluster_bus_debug_msg = sdsempty();
+    server.cluster->myself->debug_message = sdsempty();
     server.reply_buffer_peak_reset_time = REPLY_BUFFER_DEFAULT_PEAK_RESET_TIME;
     server.reply_buffer_resizing_enabled = 1;
     server.client_mem_usage_buckets = NULL;

--- a/src/server.h
+++ b/src/server.h
@@ -2089,7 +2089,6 @@ struct valkeyServer {
     uint32_t debug_cluster_close_link_on_packet_drop : 1;
     /* Debug config to control the random ping. When set, we will disable the random ping in clusterCron. */
     uint32_t debug_cluster_disable_random_ping : 1;
-    sds cluster_bus_debug_msg;               /* Debug message to propagate on cluster bus */
     sds cached_cluster_slot_info[CACHE_CONN_TYPE_MAX]; /* Index in array is a bitwise or of CACHE_CONN_TYPE_* */
     /* Scripting */
     mstime_t busy_reply_threshold;  /* Script / module timeout in milliseconds */

--- a/src/server.h
+++ b/src/server.h
@@ -2089,6 +2089,7 @@ struct valkeyServer {
     uint32_t debug_cluster_close_link_on_packet_drop : 1;
     /* Debug config to control the random ping. When set, we will disable the random ping in clusterCron. */
     uint32_t debug_cluster_disable_random_ping : 1;
+    sds cluster_bus_debug_msg;               /* Debug message to propagate on cluster bus */
     sds cached_cluster_slot_info[CACHE_CONN_TYPE_MAX]; /* Index in array is a bitwise or of CACHE_CONN_TYPE_* */
     /* Scripting */
     mstime_t busy_reply_threshold;  /* Script / module timeout in milliseconds */


### PR DESCRIPTION
## Summary
- introduce debug-message extension stored per node
- add DEBUG `CLUSTER-MSG-SET` to update the local debug message
- add DEBUG `CLUSTERMSGGET <node-id>` to retrieve a node's message
- propagate the debug message with ping/pong packets
- store each node's last debug message separately
- remove the tcl test for this feature

## Testing
- `make -j4`
- `make test` *(fails: Interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6849f0498e1083239bdc52b33894dd07