### PR TITLE
Add debug message cluster test

### DIFF
--- a/tests/unit/cluster/cluster-debug-msg-extension.tcl
+++ b/tests/unit/cluster/cluster-debug-msg-extension.tcl
@@ -1,0 +1,39 @@
+# Test cluster debug message extension propagation
+
+proc debug_msg_sum_reached {} {
+    set nodecount [llength $::servers]
+    for {set i 0} {$i < $nodecount} {incr i} {
+        set msgmap [R $i DEBUG CLUSTER-MSG-GET]
+        set sum 0
+        foreach {id val} $msgmap {
+            incr sum $val
+        }
+        if {$sum != $nodecount} {
+            return 0
+        }
+    }
+    return 1
+}
+
+start_cluster 3 3 {tags {external:skip cluster}} {
+    test "Debug message propagation" {
+        set nodecount [llength $::servers]
+        set start_time [clock milliseconds]
+
+        for {set i 0} {$i < $nodecount} {incr i} {
+            R $i DEBUG CLUSTER-MSG-SET 1
+        }
+
+        wait_for_condition 1000 50 {
+            [debug_msg_sum_reached]
+        } else {
+            fail "debug message not propagated across cluster"
+        }
+
+        set end_time [clock milliseconds]
+        set duration [expr {$end_time - $start_time}]
+        puts "Time to propagate debug message: $duration ms"
+    }
+}
+
+


### PR DESCRIPTION
## Summary
- add a unit test for cluster debug message propagation

## Testing
- `./runtest --single unit/cluster/cluster-debug-msg-extension` *(fails: Can't start src/valkey-server)*

------
https://chatgpt.com/codex/tasks/task_e_684cee320a8c83239d0441435fa6244e